### PR TITLE
Replace Gnosis viaTypes by Safe

### DIFF
--- a/examples/create-batch-proposal/index.js
+++ b/examples/create-batch-proposal/index.js
@@ -68,7 +68,7 @@ async function main() {
       description: 'Mint, transfer and modify access control',
       type: 'batch',
       via: safeAddress,
-      viaType: 'Gnosis Safe',
+      viaType: 'Safe',
       metadata: {}, // Required field but empty
       steps,
     },

--- a/examples/create-proposal/index.js
+++ b/examples/create-proposal/index.js
@@ -18,7 +18,7 @@ async function main() {
       functionInterface: { name: 'setNumber', inputs: [{ name: 'value', type: 'uint256' }] },
       functionInputs: ['42'],
       via: '0x534Fba01B138915C9F6D2b58bCF5C4712852cfE8',
-      viaType: 'Gnosis Safe',
+      viaType: 'Safe',
     },
   });
 

--- a/packages/deploy/README.md
+++ b/packages/deploy/README.md
@@ -80,7 +80,7 @@ There are a number of optional fields, these include:
 - `proxyAdminAddress` - The Proxy Admin address in case you are upgrading with a transparent proxy.
 - `newImplementationABI` - The ABI of the new implementation address. This will be required if the implementation contract does not exist in OpenZeppelin Defender.
 - `approvalProcessId` - The approval process ID in case you wish to override the default global approval process.
-- `senderAddress` - The address you wish to create the Gnosis proposal with. When creating an upgrade proposal, we provide you with an external link to the Safe UI. This will lead you to a proposal ready to be signed. This proposal will contain information about what upgrade to execute, as well as who initiated the proposal. The `senderAddress` property lets you customise define which address this is.
+- `senderAddress` - The address you wish to create the Safe proposal with. When creating an upgrade proposal, we provide you with an external link to the Safe UI. This will lead you to a proposal ready to be signed. This proposal will contain information about what upgrade to execute, as well as who initiated the proposal. The `senderAddress` property lets you customise define which address this is.
 
 Below is an example of a contract upgrade request which responds with a `UpgradeContractResponse`
 

--- a/packages/deploy/README.md
+++ b/packages/deploy/README.md
@@ -80,7 +80,7 @@ There are a number of optional fields, these include:
 - `proxyAdminAddress` - The Proxy Admin address in case you are upgrading with a transparent proxy.
 - `newImplementationABI` - The ABI of the new implementation address. This will be required if the implementation contract does not exist in OpenZeppelin Defender.
 - `approvalProcessId` - The approval process ID in case you wish to override the default global approval process.
-- `senderAddress` - The address you wish to create the Gnosis proposal with. When creating an upgrade proposal, we provide you with an external link to the Gnosis Safe UI. This will lead you to a proposal ready to be signed. This proposal will contain information about what upgrade to execute, as well as who initiated the proposal. The `senderAddress` property lets you customise define which address this is.
+- `senderAddress` - The address you wish to create the Gnosis proposal with. When creating an upgrade proposal, we provide you with an external link to the Safe UI. This will lead you to a proposal ready to be signed. This proposal will contain information about what upgrade to execute, as well as who initiated the proposal. The `senderAddress` property lets you customise define which address this is.
 
 Below is an example of a contract upgrade request which responds with a `UpgradeContractResponse`
 

--- a/packages/deploy/src/models/approval-process.ts
+++ b/packages/deploy/src/models/approval-process.ts
@@ -13,7 +13,7 @@ export interface ApprovalProcessResponse {
     | 'EOA'
     | 'Contract'
     | 'Multisig'
-    | 'Gnosis Safe'
+    | 'Safe'
     | 'Gnosis Multisig'
     | 'Relayer'
     | 'Unknown'

--- a/packages/deploy/src/models/approval-process.ts
+++ b/packages/deploy/src/models/approval-process.ts
@@ -14,6 +14,7 @@ export interface ApprovalProcessResponse {
     | 'Contract'
     | 'Multisig'
     | 'Safe'
+    | 'Gnosis Multisig'
     | 'Relayer'
     | 'Unknown'
     | 'Timelock Controller'

--- a/packages/deploy/src/models/approval-process.ts
+++ b/packages/deploy/src/models/approval-process.ts
@@ -14,7 +14,6 @@ export interface ApprovalProcessResponse {
     | 'Contract'
     | 'Multisig'
     | 'Safe'
-    | 'Gnosis Multisig'
     | 'Relayer'
     | 'Unknown'
     | 'Timelock Controller'

--- a/packages/proposal/src/models/proposal.ts
+++ b/packages/proposal/src/models/proposal.ts
@@ -16,7 +16,7 @@ export interface ExternalApiCreateProposalRequest {
   type: ProposalType;
   metadata?: ProposalMetadata;
   via?: Address;
-  viaType?: 'EOA' | 'Gnosis Safe' | 'Gnosis Multisig' | 'Relayer';
+  viaType?: 'EOA' | 'Safe' | 'Gnosis Multisig' | 'Relayer';
   functionInterface?: ProposalTargetFunction;
   functionInputs?: ProposalFunctionInputs;
   steps?: ProposalStep[];

--- a/packages/proposal/src/models/proposal.ts
+++ b/packages/proposal/src/models/proposal.ts
@@ -16,7 +16,7 @@ export interface ExternalApiCreateProposalRequest {
   type: ProposalType;
   metadata?: ProposalMetadata;
   via?: Address;
-  viaType?: 'EOA' | 'Safe' | 'Relayer';
+  viaType?: 'EOA' | 'Safe' | 'Gnosis Multisig' | 'Relayer';
   functionInterface?: ProposalTargetFunction;
   functionInputs?: ProposalFunctionInputs;
   steps?: ProposalStep[];

--- a/packages/proposal/src/models/proposal.ts
+++ b/packages/proposal/src/models/proposal.ts
@@ -16,7 +16,7 @@ export interface ExternalApiCreateProposalRequest {
   type: ProposalType;
   metadata?: ProposalMetadata;
   via?: Address;
-  viaType?: 'EOA' | 'Safe' | 'Gnosis Multisig' | 'Relayer';
+  viaType?: 'EOA' | 'Safe' | 'Relayer';
   functionInterface?: ProposalTargetFunction;
   functionInputs?: ProposalFunctionInputs;
   steps?: ProposalStep[];


### PR DESCRIPTION

https://linear.app/openzeppelin-development/issue/PLAT-2497/rename-all-occurrences-from-gnosis-safe-safe