### PR TITLE
enforce base package to build first

### DIFF
--- a/examples/create-forked-network/index.js
+++ b/examples/create-forked-network/index.js
@@ -11,7 +11,7 @@ async function main() {
     name: 'MyForkedNetwork',
     forkedNetwork: 'mainnet',
     rpcUrl: '', // Add your RPC URL here
-  })
+  });
 
   console.log(network);
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "nx-build-test-skip-cache": "pnpm run build-test --skip-nx-cache",
     "nx-test-skip-cache": "pnpm run test --skip-nx-cache",
     "build": "nx run-many -t build --parallel=1",
-    "build-test": "nx run-many -t style,build,test",
+    "build-test": "nx run-many -t style,build,test --projects=@openzeppelin/defender-base-client,*  --parallel=false",
     "lint:check": "eslint 'packages/**/src/**/*.{js,ts}' --quiet",
     "lint:fix": "pnpm prettier:fix && pnpm lint:check && pnpm prettier:check",
     "prettier:check": "prettier --check '**/*.{js,ts,tsx}'",

--- a/packages/relay-signer/src/models/relayer.ts
+++ b/packages/relay-signer/src/models/relayer.ts
@@ -1,6 +1,11 @@
 import https from 'https';
 import { Network } from '@openzeppelin/defender-sdk-base-client';
-import { ListTransactionsRequest, PaginatedTransactionResponse, RelayerTransaction, RelayerTransactionPayload } from './transactions';
+import {
+  ListTransactionsRequest,
+  PaginatedTransactionResponse,
+  RelayerTransaction,
+  RelayerTransactionPayload,
+} from './transactions';
 import { JsonRpcResponse, SignMessagePayload, SignTypedDataPayload, SignedMessagePayload } from './rpc';
 
 // TODO Defender Address model for this

--- a/packages/relay-signer/src/models/transactions.ts
+++ b/packages/relay-signer/src/models/transactions.ts
@@ -71,8 +71,7 @@ export type ListTransactionsRequest = {
   usePagination?: boolean;
 };
 
-
 export type PaginatedTransactionResponse = {
   items: RelayerTransaction[];
   next?: string;
-}
+};

--- a/packages/relay-signer/src/relayer.ts
+++ b/packages/relay-signer/src/relayer.ts
@@ -1,6 +1,11 @@
 import { IRelayer, RelayerGetResponse, RelayerParams } from './models/relayer';
 import { JsonRpcResponse, SignMessagePayload, SignTypedDataPayload, SignedMessagePayload } from './models/rpc';
-import { ListTransactionsRequest, PaginatedTransactionResponse, RelayerTransaction, RelayerTransactionPayload } from './models/transactions';
+import {
+  ListTransactionsRequest,
+  PaginatedTransactionResponse,
+  RelayerTransaction,
+  RelayerTransactionPayload,
+} from './models/transactions';
 import { isApiCredentials, isActionCredentials, validatePayload } from './ethers/utils';
 import { RelaySignerClient } from './api';
 import { DefenderRelayProvider, DefenderRelaySigner, DefenderRelaySignerOptions } from './ethers';
@@ -66,7 +71,9 @@ export class Relayer implements IRelayer {
     return this.relayer.getTransaction(id);
   }
 
-  public listTransactions(criteria?: ListTransactionsRequest): Promise<RelayerTransaction[] | PaginatedTransactionResponse> {
+  public listTransactions(
+    criteria?: ListTransactionsRequest,
+  ): Promise<RelayerTransaction[] | PaginatedTransactionResponse> {
     return this.relayer.listTransactions(criteria);
   }
 


### PR DESCRIPTION
pnpm nx-build-test-skip-cache command was failing due to parallel building, some packages depend on base to build properly, so I changed secuential builds, this is slower but seems to be necesary.

cc @tirumerla  