### PR TITLE
Add support for retrieving account usage via sdk

### DIFF
--- a/examples/get-usage/index.js
+++ b/examples/get-usage/index.js
@@ -1,0 +1,17 @@
+require('dotenv').config();
+
+const { Defender } = require('@openzeppelin/defender-sdk');
+
+async function main() {
+  const creds = { apiKey: process.env.API_KEY, apiSecret: process.env.API_SECRET };
+  const client = new Defender(creds);
+
+  // List Account Usage
+  const usage = await client.account.getUsage();
+
+  console.log(usage);
+}
+
+if (require.main === module) {
+  main().catch(console.error);
+}

--- a/examples/get-usage/package.json
+++ b/examples/get-usage/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@openzeppelin/defender-sdk-example-get-usage",
+  "version": "1.3.0",
+  "private": true,
+  "main": "index.js",
+  "author": "Zeljko Markovic <zeljko@openzeppelin.com>",
+  "license": "MIT",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "@openzeppelin/defender-sdk": "1.3.0",
+    "dotenv": "^16.3.1"
+  }
+}

--- a/packages/account/README.md
+++ b/packages/account/README.md
@@ -1,0 +1,5 @@
+# Defender SDK Account Client
+
+The OpenZeppelin Defender provides a security operations (SecOps) platform for Ethereum with built-in best practices. Development teams implement Defender to ship faster and minimize security risks.
+
+This library provides methods related to networks. See Examples for usage.

--- a/packages/account/jest.config.js
+++ b/packages/account/jest.config.js
@@ -1,0 +1,1 @@
+module.exports = require('../../jest.config');

--- a/packages/account/package.json
+++ b/packages/account/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@openzeppelin/defender-sdk",
+  "name": "@openzeppelin/defender-sdk-account-client",
   "version": "1.3.0",
   "description": "",
   "main": "./lib/index.js",
@@ -21,15 +21,8 @@
   "license": "MIT",
   "dependencies": {
     "@openzeppelin/defender-sdk-base-client": "^1.3.0",
-    "@openzeppelin/defender-sdk-monitor-client": "^1.3.0",
-    "@openzeppelin/defender-sdk-action-client": "^1.3.0",
-    "@openzeppelin/defender-sdk-relay-client": "^1.3.0",
-    "@openzeppelin/defender-sdk-proposal-client": "^1.3.0",
-    "@openzeppelin/defender-sdk-deploy-client": "^1.3.0",
-    "@openzeppelin/defender-sdk-notification-channel-client": "^1.3.0",
-    "@openzeppelin/defender-sdk-relay-signer-client": "^1.3.0",
-    "@openzeppelin/defender-sdk-network-client": "^1.3.0",
-    "@openzeppelin/defender-sdk-account-client": "^1.3.0"
+    "axios": "^1.4.0",
+    "lodash": "^4.17.21"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/account/src/api/index.ts
+++ b/packages/account/src/api/index.ts
@@ -1,0 +1,27 @@
+import { BaseApiClient } from '@openzeppelin/defender-sdk-base-client';
+import { AccountUsageResponse } from '../models/account';
+
+const PATH = '/account';
+
+export class AccountClient extends BaseApiClient {
+  protected getPoolId(): string {
+    return process.env.DEFENDER_POOL_ID ?? 'us-west-2_94f3puJWv';
+  }
+
+  protected getPoolClientId(): string {
+    return process.env.DEFENDER_POOL_CLIENT_ID ?? '40e58hbc7pktmnp9i26hh5nsav';
+  }
+
+  protected getApiUrl(): string {
+    return process.env.DEFENDER_API_URL ?? 'https://defender-api.openzeppelin.com/v2/';
+  }
+
+  public async getUsage(params?: { date?: string | Date; quotas: string[] }): Promise<AccountUsageResponse> {
+    const searchParams = new URLSearchParams({
+      ...(params?.quotas && { quotas: params.quotas.join(',') }),
+      ...(params?.date && { date: new Date(params.date).toISOString() }),
+    });
+
+    return this.apiCall(async (api) => api.get(`${PATH}/usage?${searchParams.toString()}`));
+  }
+}

--- a/packages/account/src/index.ts
+++ b/packages/account/src/index.ts
@@ -1,0 +1,4 @@
+export { AccountClient } from './api';
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+export const VERSION = require('../package.json').version;

--- a/packages/account/src/index.ts
+++ b/packages/account/src/index.ts
@@ -1,4 +1,5 @@
 export { AccountClient } from './api';
+export { AccountUsageResponse } from './models/account';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 export const VERSION = require('../package.json').version;

--- a/packages/account/src/models/account.ts
+++ b/packages/account/src/models/account.ts
@@ -1,0 +1,16 @@
+type AccountUsage =
+  | {
+      name: string;
+      description: string;
+      used: number;
+      limit: number;
+      overage?: number;
+      remaining: number;
+      period: 'hour' | 'month' | 'total';
+    }
+  | {
+      name: string;
+      error: string;
+    };
+
+export type AccountUsageResponse = Record<string, AccountUsage>;

--- a/packages/account/tsconfig.json
+++ b/packages/account/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "code-style/tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "outDir": "./lib",
+    "skipLibCheck": true,
+    "sourceMap": false
+  },
+  "include": ["./src"],
+  "exclude": ["**/*.test.ts", "**/__mocks__/*"]
+}

--- a/packages/defender-sdk/src/index.ts
+++ b/packages/defender-sdk/src/index.ts
@@ -5,6 +5,7 @@ import { ProposalClient } from '@openzeppelin/defender-sdk-proposal-client';
 import { DeployClient } from '@openzeppelin/defender-sdk-deploy-client';
 import { NotificationChannelClient } from '@openzeppelin/defender-sdk-notification-channel-client';
 import { NetworkClient } from '@openzeppelin/defender-sdk-network-client';
+import { AccountClient } from '@openzeppelin/defender-sdk-account-client';
 
 import { Newable, ClientParams } from './types';
 import { ActionRelayerParams, Relayer as RelaySignerClient } from '@openzeppelin/defender-sdk-relay-signer-client';
@@ -55,6 +56,10 @@ export class Defender {
 
   get network() {
     return getClient(NetworkClient, { apiKey: this.apiKey, apiSecret: this.apiSecret });
+  }
+
+  get account() {
+    return getClient(AccountClient, { apiKey: this.apiKey, apiSecret: this.apiSecret });
   }
 
   get monitor() {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
     dependencies:
       '@openzeppelin/defender-sdk-base-client':
         specifier: 1.2.0
-        version: link:packages/base
+        version: 1.2.0
       axios:
         specifier: ^1.4.0
         version: 1.4.0
@@ -79,7 +79,7 @@ importers:
   examples/create-action:
     dependencies:
       '@openzeppelin/defender-sdk':
-        specifier: 1.2.0
+        specifier: 1.3.0
         version: link:../../packages/defender-sdk
       dotenv:
         specifier: ^16.3.1
@@ -88,7 +88,7 @@ importers:
   examples/create-batch-proposal:
     dependencies:
       '@openzeppelin/defender-sdk':
-        specifier: 1.2.0
+        specifier: 1.3.0
         version: link:../../packages/defender-sdk
       dotenv:
         specifier: ^16.3.1
@@ -97,7 +97,7 @@ importers:
   examples/create-forked-network:
     dependencies:
       '@openzeppelin/defender-sdk':
-        specifier: 1.2.0
+        specifier: 1.3.0
         version: link:../../packages/defender-sdk
       dotenv:
         specifier: ^16.3.1
@@ -115,7 +115,7 @@ importers:
   examples/create-proposal:
     dependencies:
       '@openzeppelin/defender-sdk':
-        specifier: 1.2.0
+        specifier: 1.3.0
         version: link:../../packages/defender-sdk
       dotenv:
         specifier: ^16.3.1
@@ -124,7 +124,7 @@ importers:
   examples/create-relayer:
     dependencies:
       '@openzeppelin/defender-sdk':
-        specifier: 1.2.0
+        specifier: 1.3.0
         version: link:../../packages/defender-sdk
       dotenv:
         specifier: ^16.3.1
@@ -133,7 +133,7 @@ importers:
   examples/create-relayer-key:
     dependencies:
       '@openzeppelin/defender-sdk':
-        specifier: 1.2.0
+        specifier: 1.3.0
         version: link:../../packages/defender-sdk
       dotenv:
         specifier: ^16.3.1
@@ -142,7 +142,7 @@ importers:
   examples/deploy-contract:
     dependencies:
       '@openzeppelin/defender-sdk':
-        specifier: 1.2.0
+        specifier: 1.3.0
         version: link:../../packages/defender-sdk
       dotenv:
         specifier: ^16.3.1
@@ -151,7 +151,7 @@ importers:
   examples/ethers-signer:
     dependencies:
       '@openzeppelin/defender-sdk':
-        specifier: 1.2.0
+        specifier: 1.3.0
         version: link:../../packages/defender-sdk
       dotenv:
         specifier: ^16.3.1
@@ -160,10 +160,19 @@ importers:
         specifier: ^5.6.1
         version: 5.7.2
 
+  examples/get-usage:
+    dependencies:
+      '@openzeppelin/defender-sdk':
+        specifier: 1.3.0
+        version: link:../../packages/defender-sdk
+      dotenv:
+        specifier: ^16.3.1
+        version: 16.3.1
+
   examples/list-networks:
     dependencies:
       '@openzeppelin/defender-sdk':
-        specifier: 1.2.0
+        specifier: 1.3.0
         version: link:../../packages/defender-sdk
       dotenv:
         specifier: ^16.3.1
@@ -172,7 +181,7 @@ importers:
   examples/relayer-signer-actions:
     dependencies:
       '@openzeppelin/defender-sdk':
-        specifier: 1.2.0
+        specifier: 1.3.0
         version: link:../../packages/defender-sdk
       dotenv:
         specifier: ^16.3.1
@@ -181,7 +190,7 @@ importers:
   examples/simulate-proposal:
     dependencies:
       '@openzeppelin/defender-sdk':
-        specifier: 1.2.0
+        specifier: 1.3.0
         version: link:../../packages/defender-sdk
       dotenv:
         specifier: ^16.3.1
@@ -193,7 +202,7 @@ importers:
   examples/update-action:
     dependencies:
       '@openzeppelin/defender-sdk':
-        specifier: 1.2.0
+        specifier: 1.3.0
         version: link:../../packages/defender-sdk
       dotenv:
         specifier: ^16.3.1
@@ -202,7 +211,7 @@ importers:
   examples/update-monitor:
     dependencies:
       '@openzeppelin/defender-sdk':
-        specifier: 1.2.0
+        specifier: 1.3.0
         version: link:../../packages/defender-sdk
       dotenv:
         specifier: ^16.3.1
@@ -211,7 +220,7 @@ importers:
   examples/update-notification-category:
     dependencies:
       '@openzeppelin/defender-sdk':
-        specifier: 1.2.0
+        specifier: 1.3.0
         version: link:../../packages/defender-sdk
       dotenv:
         specifier: ^16.3.1
@@ -220,7 +229,7 @@ importers:
   examples/update-relayer:
     dependencies:
       '@openzeppelin/defender-sdk':
-        specifier: 1.2.0
+        specifier: 1.3.0
         version: link:../../packages/defender-sdk
       dotenv:
         specifier: ^16.3.1
@@ -229,16 +238,28 @@ importers:
   examples/upgrade-contract:
     dependencies:
       '@openzeppelin/defender-sdk':
-        specifier: 1.2.0
+        specifier: 1.3.0
         version: link:../../packages/defender-sdk
       dotenv:
         specifier: ^16.3.1
         version: 16.3.1
 
+  packages/account:
+    dependencies:
+      '@openzeppelin/defender-sdk-base-client':
+        specifier: ^1.3.0
+        version: link:../base
+      axios:
+        specifier: ^1.4.0
+        version: 1.4.0
+      lodash:
+        specifier: ^4.17.21
+        version: 4.17.21
+
   packages/action:
     dependencies:
       '@openzeppelin/defender-sdk-base-client':
-        specifier: ^1.2.0
+        specifier: ^1.3.0
         version: link:../base
       axios:
         specifier: ^1.4.0
@@ -271,32 +292,35 @@ importers:
 
   packages/defender-sdk:
     dependencies:
+      '@openzeppelin/defender-sdk-account-client':
+        specifier: ^1.3.0
+        version: link:../account
       '@openzeppelin/defender-sdk-action-client':
-        specifier: ^1.2.0
+        specifier: ^1.3.0
         version: link:../action
       '@openzeppelin/defender-sdk-base-client':
-        specifier: ^1.2.0
+        specifier: ^1.3.0
         version: link:../base
       '@openzeppelin/defender-sdk-deploy-client':
-        specifier: ^1.2.0
+        specifier: ^1.3.0
         version: link:../deploy
       '@openzeppelin/defender-sdk-monitor-client':
-        specifier: ^1.2.0
+        specifier: ^1.3.0
         version: link:../monitor
       '@openzeppelin/defender-sdk-network-client':
-        specifier: ^1.2.0
+        specifier: ^1.3.0
         version: link:../network
       '@openzeppelin/defender-sdk-notification-channel-client':
-        specifier: ^1.2.0
+        specifier: ^1.3.0
         version: link:../notification-channel
       '@openzeppelin/defender-sdk-proposal-client':
-        specifier: ^1.2.0
+        specifier: ^1.3.0
         version: link:../proposal
       '@openzeppelin/defender-sdk-relay-client':
-        specifier: ^1.2.0
+        specifier: ^1.3.0
         version: link:../relay
       '@openzeppelin/defender-sdk-relay-signer-client':
-        specifier: ^1.2.0
+        specifier: ^1.3.0
         version: link:../relay-signer
 
   packages/deploy:
@@ -305,7 +329,7 @@ importers:
         specifier: ^5.6.3
         version: 5.6.3
       '@openzeppelin/defender-sdk-base-client':
-        specifier: ^1.2.0
+        specifier: ^1.3.0
         version: link:../base
       axios:
         specifier: ^1.4.0
@@ -320,7 +344,7 @@ importers:
         specifier: ^5.6.3
         version: 5.6.3
       '@openzeppelin/defender-sdk-base-client':
-        specifier: ^1.2.0
+        specifier: ^1.3.0
         version: link:../base
       axios:
         specifier: ^1.4.0
@@ -335,7 +359,7 @@ importers:
         specifier: ^5.6.3
         version: 5.6.3
       '@openzeppelin/defender-sdk-base-client':
-        specifier: ^1.2.0
+        specifier: ^1.3.0
         version: link:../base
       axios:
         specifier: ^1.4.0
@@ -350,7 +374,7 @@ importers:
         specifier: ^5.6.3
         version: 5.6.3
       '@openzeppelin/defender-sdk-base-client':
-        specifier: ^1.2.0
+        specifier: ^1.3.0
         version: link:../base
       axios:
         specifier: ^1.4.0
@@ -362,7 +386,7 @@ importers:
   packages/proposal:
     dependencies:
       '@openzeppelin/defender-sdk-base-client':
-        specifier: ^1.2.0
+        specifier: ^1.3.0
         version: link:../base
       axios:
         specifier: ^1.4.0
@@ -377,7 +401,7 @@ importers:
   packages/relay:
     dependencies:
       '@openzeppelin/defender-sdk-base-client':
-        specifier: ^1.2.0
+        specifier: ^1.3.0
         version: link:../base
       axios:
         specifier: ^1.4.0
@@ -413,7 +437,7 @@ importers:
         specifier: ^5.7.0
         version: 5.7.0
       '@openzeppelin/defender-sdk-base-client':
-        specifier: ^1.2.0
+        specifier: ^1.3.0
         version: link:../base
       amazon-cognito-identity-js:
         specifier: ^6.0.1
@@ -1898,10 +1922,10 @@ packages:
     dev: true
     optional: true
 
-  /@openzeppelin/defender-sdk-action-client@1.2.0:
-    resolution: {integrity: sha512-1fILCk8dckTvDJXY328hEfrH/UqkUlOq6XiwPqzWUB9RVfTWItgAFsxyyHwPssZOrCviAKT4YK4NRtbctpkzpA==}
+  /@openzeppelin/defender-sdk-action-client@1.3.0:
+    resolution: {integrity: sha512-j1AzY4A+4ywHgI0SYJfh1LC5bNR430TCJmNfyn7D5ZM32sXPvTPu0SAQKGz6bYRFp+YAB6bOJZDyT1J3YbnxMw==}
     dependencies:
-      '@openzeppelin/defender-sdk-base-client': 1.2.0
+      '@openzeppelin/defender-sdk-base-client': 1.3.0
       axios: 1.4.0
       glob: 7.2.3
       jszip: 3.8.0
@@ -1920,11 +1944,20 @@ packages:
       - encoding
     dev: false
 
-  /@openzeppelin/defender-sdk-deploy-client@1.2.0:
-    resolution: {integrity: sha512-kUBRKMSQiTZ8urP236L68k5X8Eg1ys2FDYMeuJ22GhXFAC2M1l6OaXNFolFBSzmS5t/x8BkJU6+RCyoCqO2qxg==}
+  /@openzeppelin/defender-sdk-base-client@1.3.0:
+    resolution: {integrity: sha512-OMMt7NaAL8C95ralF9nMeKZpg96COLZT9FPpGpPsI7aB8fVZfCM8+6k99gTF44hMS6IsRdN2WthS3m7VzQeeoA==}
+    dependencies:
+      amazon-cognito-identity-js: 6.0.1
+      async-retry: 1.3.3
+    transitivePeerDependencies:
+      - encoding
+    dev: false
+
+  /@openzeppelin/defender-sdk-deploy-client@1.3.0:
+    resolution: {integrity: sha512-RTYM3HnVvD2d5NoYfTug8UwT41e0Jjwb13lk9v0Jl8z7mcclUVvAnKD4DHJ4b8RhKpg4B15oLQK/Igzjg1HHRA==}
     dependencies:
       '@ethersproject/abi': 5.7.0
-      '@openzeppelin/defender-sdk-base-client': 1.2.0
+      '@openzeppelin/defender-sdk-base-client': 1.3.0
       axios: 1.4.0
       lodash: 4.17.21
     transitivePeerDependencies:
@@ -1932,11 +1965,11 @@ packages:
       - encoding
     dev: false
 
-  /@openzeppelin/defender-sdk-monitor-client@1.2.0:
-    resolution: {integrity: sha512-6g+jlgjUMQxqN91DtJlDEMerf9mqKBW3HVROMuNjEnFqtEmiasL6GQ7HkbE/fmo+gzbBqX5VgstemX5XJgajWQ==}
+  /@openzeppelin/defender-sdk-monitor-client@1.3.0:
+    resolution: {integrity: sha512-0drfifN4lk4Jpn5goU0imuuvQfxH8EDHUCEQSqxHbubsmNMrI+RqnHSuLZ26VceXbmcVbpfrYhVPnIVyyL4bVw==}
     dependencies:
       '@ethersproject/abi': 5.7.0
-      '@openzeppelin/defender-sdk-base-client': 1.2.0
+      '@openzeppelin/defender-sdk-base-client': 1.3.0
       axios: 1.4.0
       lodash: 4.17.21
     transitivePeerDependencies:
@@ -1944,11 +1977,11 @@ packages:
       - encoding
     dev: false
 
-  /@openzeppelin/defender-sdk-notification-channel-client@1.2.0:
-    resolution: {integrity: sha512-Ax8TAwGBB4FLUpY7K3Zs8EH2Rntxm6dYcupUf5jRiSjtv4ZNMl+zzI0QsdjnkrZylbwSehGx45snic1ldQuHtQ==}
+  /@openzeppelin/defender-sdk-notification-channel-client@1.3.0:
+    resolution: {integrity: sha512-W5YrxB9nLXavtdVUpvgepXhBKLvJcJMcbWDs78/gpvLicKbpTXD0V1Vg9UjSstGUbOeU9yOqYSIzDqj6+cgq3Q==}
     dependencies:
       '@ethersproject/abi': 5.7.0
-      '@openzeppelin/defender-sdk-base-client': 1.2.0
+      '@openzeppelin/defender-sdk-base-client': 1.3.0
       axios: 1.4.0
       lodash: 4.17.21
     transitivePeerDependencies:
@@ -1956,10 +1989,10 @@ packages:
       - encoding
     dev: false
 
-  /@openzeppelin/defender-sdk-proposal-client@1.2.0:
-    resolution: {integrity: sha512-aiSkniJzYZAXRVOQ93Bg85mf2h3T7hZQJh7bZURTcSJinf8caLTDmX2UlkVj+ucboqWIPcOoIN1nS4daq2z5pA==}
+  /@openzeppelin/defender-sdk-proposal-client@1.3.0:
+    resolution: {integrity: sha512-IO2ZLgYshboBB0GCURM4APaePQIjOgTEgFchik612sk41VfGfIV7Ei/r0EllNVHS4385mMH2qWe/fK6isseBzQ==}
     dependencies:
-      '@openzeppelin/defender-sdk-base-client': 1.2.0
+      '@openzeppelin/defender-sdk-base-client': 1.3.0
       axios: 1.4.0
       ethers: 5.7.2
       lodash: 4.17.21
@@ -1970,10 +2003,10 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@openzeppelin/defender-sdk-relay-client@1.2.0:
-    resolution: {integrity: sha512-6y/RgxQVnrvLLepvKxCS2ClaOM2Eq0yzkUh5RXKKMcmb27glMoiBRq0qeF5lZmeacnRybsJHwcf9hVKVCQ3AKg==}
+  /@openzeppelin/defender-sdk-relay-client@1.3.0:
+    resolution: {integrity: sha512-PhvIcy1kRM+KHSILRPLAs3CKs44VsVkx966L//52jS8b38DW3XJTdmpCNGWUCg2BRIV4qFv13BXO4qXd3u6/1g==}
     dependencies:
-      '@openzeppelin/defender-sdk-base-client': 1.2.0
+      '@openzeppelin/defender-sdk-base-client': 1.3.0
       axios: 1.4.0
       lodash: 4.17.21
     transitivePeerDependencies:
@@ -1981,8 +2014,8 @@ packages:
       - encoding
     dev: false
 
-  /@openzeppelin/defender-sdk-relay-signer-client@1.2.0(@ethersproject/abstract-provider@5.7.0)(@ethersproject/abstract-signer@5.7.0)(@ethersproject/hash@5.7.0)(@ethersproject/providers@5.7.2)(@ethersproject/transactions@5.7.0)(web3-core-helpers@1.8.2)(web3-core@1.8.2)(web3-utils@1.8.2)(web3@1.8.2):
-    resolution: {integrity: sha512-wef/CKjrgP5BQ8auq2N/j898k8pszzAYeEZvKZkyOq1QSH33D5Utihg9IogLUR0mBA52H3IhnPuJKgqU4adKSw==}
+  /@openzeppelin/defender-sdk-relay-signer-client@1.3.0(@ethersproject/abstract-provider@5.7.0)(@ethersproject/abstract-signer@5.7.0)(@ethersproject/hash@5.7.0)(@ethersproject/providers@5.7.2)(@ethersproject/transactions@5.7.0)(web3-core-helpers@1.8.2)(web3-core@1.8.2)(web3-utils@1.8.2)(web3@1.8.2):
+    resolution: {integrity: sha512-aVBvZUy3TS1WcRykcFKd1sjO+LcDQP5kxKLovwb+JFuAqigsEoiJRZktnI5zFRzHs4wfuzOUPfbPcNW89mvNVw==}
     peerDependencies:
       '@ethersproject/abstract-provider': ^5.6.1
       '@ethersproject/abstract-signer': ^5.6.2
@@ -2007,7 +2040,7 @@ packages:
       '@ethersproject/random': 5.7.0
       '@ethersproject/strings': 5.7.0
       '@ethersproject/transactions': 5.7.0
-      '@openzeppelin/defender-sdk-base-client': 1.2.0
+      '@openzeppelin/defender-sdk-base-client': 1.3.0
       amazon-cognito-identity-js: 6.0.1
       axios: 1.4.0
       lodash: 4.17.21
@@ -2023,14 +2056,14 @@ packages:
   /@openzeppelin/defender-sdk@1.0.0(@ethersproject/abstract-provider@5.7.0)(@ethersproject/abstract-signer@5.7.0)(@ethersproject/hash@5.7.0)(@ethersproject/providers@5.7.2)(@ethersproject/transactions@5.7.0)(web3-core-helpers@1.8.2)(web3-core@1.8.2)(web3-utils@1.8.2)(web3@1.8.2):
     resolution: {integrity: sha512-+Ayol7BsrgTxBB665hmDVa/lvEfRHbBTN4ENBUKRlBD0mra03doE1ROGXyOuSk6UdugNTxYOuEP1YlL5Hsb8Mw==}
     dependencies:
-      '@openzeppelin/defender-sdk-action-client': 1.2.0
-      '@openzeppelin/defender-sdk-base-client': 1.2.0
-      '@openzeppelin/defender-sdk-deploy-client': 1.2.0
-      '@openzeppelin/defender-sdk-monitor-client': 1.2.0
-      '@openzeppelin/defender-sdk-notification-channel-client': 1.2.0
-      '@openzeppelin/defender-sdk-proposal-client': 1.2.0
-      '@openzeppelin/defender-sdk-relay-client': 1.2.0
-      '@openzeppelin/defender-sdk-relay-signer-client': 1.2.0(@ethersproject/abstract-provider@5.7.0)(@ethersproject/abstract-signer@5.7.0)(@ethersproject/hash@5.7.0)(@ethersproject/providers@5.7.2)(@ethersproject/transactions@5.7.0)(web3-core-helpers@1.8.2)(web3-core@1.8.2)(web3-utils@1.8.2)(web3@1.8.2)
+      '@openzeppelin/defender-sdk-action-client': 1.3.0
+      '@openzeppelin/defender-sdk-base-client': 1.3.0
+      '@openzeppelin/defender-sdk-deploy-client': 1.3.0
+      '@openzeppelin/defender-sdk-monitor-client': 1.3.0
+      '@openzeppelin/defender-sdk-notification-channel-client': 1.3.0
+      '@openzeppelin/defender-sdk-proposal-client': 1.3.0
+      '@openzeppelin/defender-sdk-relay-client': 1.3.0
+      '@openzeppelin/defender-sdk-relay-signer-client': 1.3.0(@ethersproject/abstract-provider@5.7.0)(@ethersproject/abstract-signer@5.7.0)(@ethersproject/hash@5.7.0)(@ethersproject/providers@5.7.2)(@ethersproject/transactions@5.7.0)(web3-core-helpers@1.8.2)(web3-core@1.8.2)(web3-utils@1.8.2)(web3@1.8.2)
     transitivePeerDependencies:
       - '@ethersproject/abstract-provider'
       - '@ethersproject/abstract-signer'


### PR DESCRIPTION
This PR will allow users to retrieve their account usage.

New defender-sdk client `account` was added as holder for this logic.

Parent PR: https://github.com/OpenZeppelin/defender/pull/4908