### PR TITLE
relaySigner: avoid resolving ENS name by default

### DIFF
--- a/packages/relay-signer/src/ethers/signer.ts
+++ b/packages/relay-signer/src/ethers/signer.ts
@@ -204,8 +204,8 @@ export class DefenderRelaySigner extends JsonRpcSigner {
   async populateTransaction(transaction: DefenderTransactionRequest): Promise<DefenderTransactionRequest> {
     const tx: DefenderTransactionRequest = await resolveProperties(this.checkTransaction(transaction));
     if (tx.to != null) {
-      const toAsString = await resolveAddress(tx.to);
-      tx.to = (await this.resolveName(toAsString)) ?? toAsString;
+      // relayer provider acts as name resolver if parameter is an ENS name
+      tx.to = await resolveAddress(tx.to, this.provider);
     }
 
     if (tx.gasLimit == null) {


### PR DESCRIPTION
## Description

Networks that don't support ENS by default, such as base-sepolia or arbitrum-sepolia, would fail in transactions using ethers signer when `to` parameter is set, because previous logic assumes that resolveEns would fail gracefully when it actually throws an error.
New logic should delegate the ENS resolution to `resolveAddress` function in ethers v6 

https://linear.app/openzeppelin-development/issue/PLAT-4392/relay-signer-failing-to-send-transaction-when-used-in-ethers-v6