### PR TITLE
Include httpsAgent param in client packages

### DIFF
--- a/packages/defender-sdk/src/index.ts
+++ b/packages/defender-sdk/src/index.ts
@@ -55,7 +55,11 @@ export class Defender {
   }
 
   public networks(opts?: ListNetworkRequestOptions): Promise<Network[]> {
-    return getClient(NetworkClient, { apiKey: this.apiKey, apiSecret: this.apiSecret }).listSupportedNetworks(opts);
+    return getClient(NetworkClient, {
+      apiKey: this.apiKey,
+      apiSecret: this.apiSecret,
+      httpsAgent: this.httpsAgent,
+    }).listSupportedNetworks(opts);
   }
 
   get network() {

--- a/packages/defender-sdk/src/index.ts
+++ b/packages/defender-sdk/src/index.ts
@@ -11,6 +11,7 @@ import { Newable, ClientParams } from './types';
 import { ActionRelayerParams, Relayer as RelaySignerClient } from '@openzeppelin/defender-sdk-relay-signer-client';
 import { ListNetworkRequestOptions } from '@openzeppelin/defender-sdk-network-client/lib/models/networks';
 import { Network } from '@openzeppelin/defender-sdk-base-client';
+import https from 'https';
 
 interface DefenderOptions {
   apiKey?: string;
@@ -19,6 +20,7 @@ interface DefenderOptions {
   relayerApiSecret?: string;
   credentials?: ActionRelayerParams;
   relayerARN?: string;
+  httpsAgent?: https.Agent;
 }
 
 function getClient<T>(Client: Newable<T>, credentials: Partial<ClientParams> | ActionRelayerParams): T {
@@ -39,6 +41,7 @@ export class Defender {
   private relayerApiSecret: string | undefined;
   private actionCredentials: ActionRelayerParams | undefined;
   private actionRelayerArn: string | undefined;
+  private httpsAgent?: https.Agent;
 
   constructor(options: DefenderOptions) {
     this.apiKey = options.apiKey;
@@ -48,6 +51,7 @@ export class Defender {
     // support for using relaySigner from Defender Actions
     this.actionCredentials = options.credentials;
     this.actionRelayerArn = options.relayerARN;
+    this.httpsAgent = options.httpsAgent;
   }
 
   public networks(opts?: ListNetworkRequestOptions): Promise<Network[]> {
@@ -55,39 +59,44 @@ export class Defender {
   }
 
   get network() {
-    return getClient(NetworkClient, { apiKey: this.apiKey, apiSecret: this.apiSecret });
+    return getClient(NetworkClient, { apiKey: this.apiKey, apiSecret: this.apiSecret, httpsAgent: this.httpsAgent });
   }
 
   get account() {
-    return getClient(AccountClient, { apiKey: this.apiKey, apiSecret: this.apiSecret });
+    return getClient(AccountClient, { apiKey: this.apiKey, apiSecret: this.apiSecret, httpsAgent: this.httpsAgent });
   }
 
   get monitor() {
-    return getClient(MonitorClient, { apiKey: this.apiKey, apiSecret: this.apiSecret });
+    return getClient(MonitorClient, { apiKey: this.apiKey, apiSecret: this.apiSecret, httpsAgent: this.httpsAgent });
   }
 
   get action() {
-    return getClient(ActionClient, { apiKey: this.apiKey, apiSecret: this.apiSecret });
+    return getClient(ActionClient, { apiKey: this.apiKey, apiSecret: this.apiSecret, httpsAgent: this.httpsAgent });
   }
 
   get relay() {
-    return getClient(RelayClient, { apiKey: this.apiKey, apiSecret: this.apiSecret });
+    return getClient(RelayClient, { apiKey: this.apiKey, apiSecret: this.apiSecret, httpsAgent: this.httpsAgent });
   }
 
   get proposal() {
-    return getClient(ProposalClient, { apiKey: this.apiKey, apiSecret: this.apiSecret });
+    return getClient(ProposalClient, { apiKey: this.apiKey, apiSecret: this.apiSecret, httpsAgent: this.httpsAgent });
   }
 
   get deploy() {
-    return getClient(DeployClient, { apiKey: this.apiKey, apiSecret: this.apiSecret });
+    return getClient(DeployClient, { apiKey: this.apiKey, apiSecret: this.apiSecret, httpsAgent: this.httpsAgent });
   }
 
   get notificationChannel() {
-    return getClient(NotificationChannelClient, { apiKey: this.apiKey, apiSecret: this.apiSecret });
+    return getClient(NotificationChannelClient, {
+      apiKey: this.apiKey,
+      apiSecret: this.apiSecret,
+      httpsAgent: this.httpsAgent,
+    });
   }
 
   get relaySigner() {
     return getClient(RelaySignerClient, {
+      httpsAgent: this.httpsAgent,
       ...(this.actionCredentials ? { credentials: this.actionCredentials } : undefined),
       ...(this.actionRelayerArn ? { relayerARN: this.actionRelayerArn } : undefined),
       ...(this.relayerApiKey ? { apiKey: this.relayerApiKey } : undefined),


### PR DESCRIPTION
## Description

Adds the possibility to set a custom httpsAgent configs for client packages

Example:
```js
const client = new Defender({ 
    apiKey: process.env.API_KEY,
    apiSecret: process.env.API_SECRET, 
    httpsAgent: https.Agent({ keepAlive: true }) 
});
```