### PR TITLE
Change Output Format of Custom Ethers Example to CJS

### DIFF
--- a/examples/custom-ethers-pkg/rollup.config.ts
+++ b/examples/custom-ethers-pkg/rollup.config.ts
@@ -16,7 +16,8 @@ export default defineConfig({
   input: 'src/index.ts',
   output: {
     file: 'dist/index.js',
-    format: 'es',
+    // Defender Actions only support CJS at this time
+    format: 'cjs',
   },
   plugins: [
     fixPluginTypeImport(json)({ compact: true }),

--- a/examples/custom-ethers-pkg/src/index.ts
+++ b/examples/custom-ethers-pkg/src/index.ts
@@ -4,9 +4,12 @@ import { ContractFactory } from 'ethers';
 import ERC20Abi from '../erc20.json';
 import ERC20Bytecode from '../bytecode.json';
 import { fileURLToPath } from 'node:url';
+import { ethers } from 'ethers';
 import dotenv from 'dotenv';
 
 export async function handler(event: ActionEvent | DefenderOptions) {
+  console.log(ethers.version);
+
   const client = new Defender(event as DefenderOptions);
   const provider = client.relaySigner.getProvider();
   const signer = await client.relaySigner.getSigner(provider, { speed: 'fast' });


### PR DESCRIPTION
Defender Actions don't support ES module syntax at this time, thus the example will not work. Changing output to CommonJS fixes this 