### PR TITLE
Optimise api access by default

### DIFF
--- a/packages/base/src/api/client.ts
+++ b/packages/base/src/api/client.ts
@@ -48,7 +48,7 @@ export abstract class BaseApiClient {
     this.apiSecret = params.apiSecret;
     this.httpsAgent = params.httpsAgent;
     this.retryConfig = { retries: 3, retryDelay: exponentialDelay, ...params.retryConfig };
-    this.authConfig = params.authConfig ?? { useCredentialsCaching: false, type: 'admin' };
+    this.authConfig = params.authConfig ?? { useCredentialsCaching: true, type: 'admin' };
   }
 
   private async getAccessToken(): Promise<string> {

--- a/packages/defender-sdk/src/index.ts
+++ b/packages/defender-sdk/src/index.ts
@@ -59,7 +59,7 @@ export class Defender {
     this.httpsAgent = options.httpsAgent;
     this.retryConfig = options.retryConfig;
     this.authConfig = {
-      useCredentialsCaching: options.useCredentialsCaching ?? false,
+      useCredentialsCaching: options.useCredentialsCaching ?? true,
       type: isRelaySignerOptions(options) ? 'relay' : 'admin',
     };
   }


### PR DESCRIPTION
https://linear.app/openzeppelin-development/issue/PLAT-4889/enable-credentials-caching-by-default-for-latest-version-of-defender