### PR TITLE
feat: Add support to isProduction flag for private networks

### DIFF
--- a/examples/create-private-network/index.js
+++ b/examples/create-private-network/index.js
@@ -18,6 +18,7 @@ async function main() {
     configuration: {
       symbol: 'ETH',
     },
+    isProduction: false, // (optional) indicates if it's a testnet
   });
 
   console.log(network);

--- a/packages/network/src/api/index.test.ts
+++ b/packages/network/src/api/index.test.ts
@@ -1,6 +1,6 @@
 import { AxiosInstance } from 'axios';
 import { NetworkClient } from '.';
-import { TenantNetworkCreateRequest } from '../models/networks';
+import { PrivateNetworkCreateRequest, TenantNetworkCreateRequest } from '../models/networks';
 
 jest.mock('@openzeppelin/defender-sdk-base-client');
 jest.mock('aws-sdk');
@@ -24,7 +24,7 @@ const createForkPayload: TenantNetworkCreateRequest = {
   networkType: 'fork',
 };
 
-const createPrivatePayload: TenantNetworkCreateRequest = {
+const createPrivatePayload: PrivateNetworkCreateRequest = {
   name: 'mock-fork',
   rpcUrl: 'https://localhost:8585',
   blockExplorerUrl: 'https://localhost:8585/explorer',
@@ -32,6 +32,7 @@ const createPrivatePayload: TenantNetworkCreateRequest = {
     symbol: 'ETH',
   },
   networkType: 'private',
+  isProduction: true,
 };
 
 describe('NetworkClient', () => {

--- a/packages/network/src/api/index.ts
+++ b/packages/network/src/api/index.ts
@@ -5,6 +5,9 @@ import {
   TenantNetworkResponse,
   TenantNetworkUpdateRequest,
   ListNetworkRequestOptions,
+  PrivateNetworkCreateRequest,
+  PrivateNetworkResponse,
+  PrivateNetworkUpdateRequest,
 } from '../models/networks';
 
 const PATH = '/networks';
@@ -64,15 +67,15 @@ export class NetworkClient extends BaseApiClient {
     });
   }
 
-  public async listPrivateNetworks(): Promise<TenantNetworkResponse[]> {
+  public async listPrivateNetworks(): Promise<PrivateNetworkResponse[]> {
     return this.apiCall(async (api) => {
       return await api.get(`${PATH}/private`);
     });
   }
 
   public async createPrivateNetwork(
-    network: Omit<TenantNetworkCreateRequest, 'networkType'>,
-  ): Promise<TenantNetworkResponse> {
+    network: Omit<PrivateNetworkCreateRequest, 'networkType'>,
+  ): Promise<PrivateNetworkResponse> {
     return this.apiCall(async (api) => {
       return await api.post(`${PATH}/private`, { ...network, networkType: 'private' });
     });
@@ -84,7 +87,7 @@ export class NetworkClient extends BaseApiClient {
     });
   }
 
-  public async getPrivateNetwork(id: string): Promise<TenantNetworkResponse> {
+  public async getPrivateNetwork(id: string): Promise<PrivateNetworkResponse> {
     return this.apiCall(async (api) => {
       return await api.get(`${PATH}/private/${id}`);
     });
@@ -92,8 +95,8 @@ export class NetworkClient extends BaseApiClient {
 
   public async updatePrivateNetwork(
     id: string,
-    network: Omit<TenantNetworkUpdateRequest, 'tenantNetworkId'>,
-  ): Promise<TenantNetworkResponse> {
+    network: Omit<PrivateNetworkUpdateRequest, 'tenantNetworkId'>,
+  ): Promise<PrivateNetworkResponse> {
     return this.apiCall(async (api) => {
       return await api.put(`${PATH}/private/${id}`, { ...network, tenantNetworkId: id });
     });

--- a/packages/network/src/models/networks.ts
+++ b/packages/network/src/models/networks.ts
@@ -19,12 +19,20 @@ export interface TenantNetworkCreateRequest {
   stackResourceId?: string;
 }
 
+export interface PrivateNetworkCreateRequest extends TenantNetworkCreateRequest {
+  isProduction?: boolean;
+}
+
 export interface TenantNetworkUpdateRequest {
   tenantNetworkId: string;
   apiKey?: string;
   blockExplorerUrl?: string;
   configuration?: TenantNetworkConfiguration;
   stackResourceId?: string;
+}
+
+export interface PrivateNetworkUpdateRequest extends TenantNetworkUpdateRequest {
+  isProduction?: boolean;
 }
 
 export interface TenantNetworkResponse {
@@ -40,6 +48,10 @@ export interface TenantNetworkResponse {
   configuration?: TenantNetworkConfiguration;
   createdAt: string;
   createdBy: string;
+}
+
+export interface PrivateNetworkResponse extends TenantNetworkResponse {
+  isProduction?: boolean;
 }
 
 export interface TenantNetworkConfiguration {


### PR DESCRIPTION
# Summary

Adds support to `isProduction` flag when creating private networks to define the environment of the network.

## Checklist

- [x] Add unit tests if applicable.
