### PR TITLE
fix: Add missing dependencies that caused relay signer to fail

### DIFF
--- a/packages/relay-signer/package.json
+++ b/packages/relay-signer/package.json
@@ -20,16 +20,16 @@
   "author": "OpenZeppelin Defender <defender@openzeppelin.com>",
   "license": "MIT",
   "devDependencies": {
-    "@ethersproject/abstract-provider": "^5.6.1",
-    "@ethersproject/abstract-signer": "^5.6.2",
-    "@ethersproject/hash": "^5.6.1",
-    "@ethersproject/providers": "^5.6.8",
-    "@ethersproject/transactions": "^5.6.2",
+    "@ethersproject/abstract-provider": "^5.7.0",
+    "@ethersproject/abstract-signer": "^5.7.0",
+    "@ethersproject/hash": "^5.7.0",
+    "@ethersproject/transactions": "^5.7.0",
     "jest-mock-extended": "^3.0.5",
     "web3-core": "^1.10.4",
     "web3-core-helpers": "^1.10.0"
   },
   "dependencies": {
+    "@ethersproject/providers": "^5.7.2",
     "@ethersproject/bignumber": "^5.7.0",
     "@ethersproject/bytes": "^5.7.0",
     "@ethersproject/networks": "^5.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -219,7 +219,7 @@ importers:
         version: 16.4.5
       ethers:
         specifier: ^5.6.1
-        version: 5.7.2
+        version: 5.7.2(bufferutil@4.0.8)(utf-8-validate@5.0.10)
 
   examples/ethers-signer-v6:
     dependencies:
@@ -603,6 +603,9 @@ importers:
       '@ethersproject/properties':
         specifier: ^5.7.0
         version: 5.7.0
+      '@ethersproject/providers':
+        specifier: ^5.7.2
+        version: 5.7.2(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@ethersproject/strings':
         specifier: ^5.7.0
         version: 5.7.0
@@ -632,16 +635,13 @@ importers:
         specifier: ^5.6.1
         version: 5.7.0
       '@ethersproject/abstract-signer':
-        specifier: ^5.6.2
+        specifier: ^5.7.0
         version: 5.7.0
       '@ethersproject/hash':
-        specifier: ^5.6.1
+        specifier: ^5.7.0
         version: 5.7.0
-      '@ethersproject/providers':
-        specifier: ^5.6.8
-        version: 5.7.2(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@ethersproject/transactions':
-        specifier: ^5.6.2
+        specifier: ^5.7.0
         version: 5.7.0
       jest-mock-extended:
         specifier: ^3.0.5
@@ -7573,7 +7573,7 @@ snapshots:
       ethereum-cryptography: 0.1.3
       rlp: 2.2.7
 
-  ethers@5.7.2:
+  ethers@5.7.2(bufferutil@4.0.8)(utf-8-validate@5.0.10):
     dependencies:
       '@ethersproject/abi': 5.7.0
       '@ethersproject/abstract-provider': 5.7.0


### PR DESCRIPTION
# Summary
This PR will add @ethersproject/providers to dependencies section as this package includes all needed packages in order for ethers-v5 and providers-v5 files to work.

https://linear.app/openzeppelin-development/issue/PLAT-5016/fix-defender-sdk-relayer-signer-package

