### PR TITLE
fix: remove /v2 from basepath in most packages

### DIFF
--- a/packages/account/src/api/index.ts
+++ b/packages/account/src/api/index.ts
@@ -13,7 +13,7 @@ export class AccountClient extends BaseApiClient {
   }
 
   protected getApiUrl(): string {
-    return process.env.DEFENDER_API_URL ?? 'https://defender-api.openzeppelin.com/v2/';
+    return process.env.DEFENDER_API_URL ?? 'https://defender-api.openzeppelin.com/';
   }
 
   public async getUsage(params?: { date?: string | Date; quotas: string[] }): Promise<AccountUsageResponse> {

--- a/packages/action/src/api.ts
+++ b/packages/action/src/api.ts
@@ -33,8 +33,7 @@ export class ActionClient extends BaseApiClient {
   }
 
   protected getApiUrl(): string {
-    // TODO: update to /action when available
-    return process.env.DEFENDER_API_URL || 'https://defender-api.openzeppelin.com/v2/';
+    return process.env.DEFENDER_API_URL || 'https://defender-api.openzeppelin.com/';
   }
 
   public async list(): Promise<ActionListResponse> {

--- a/packages/deploy/src/api/index.ts
+++ b/packages/deploy/src/api/index.ts
@@ -28,7 +28,7 @@ export class DeployClient extends BaseApiClient {
   }
 
   protected getApiUrl(): string {
-    return process.env.DEFENDER_API_URL || 'https://defender-api.openzeppelin.com/v2/';
+    return process.env.DEFENDER_API_URL || 'https://defender-api.openzeppelin.com/';
   }
 
   public async deployContract(params: DeployContractRequest): Promise<DeploymentResponse> {

--- a/packages/network/src/api/index.ts
+++ b/packages/network/src/api/index.ts
@@ -22,8 +22,7 @@ export class NetworkClient extends BaseApiClient {
   }
 
   protected getApiUrl(): string {
-    // TODO: update to /monitor when available
-    return process.env.DEFENDER_API_URL || 'https://defender-api.openzeppelin.com/v2/';
+    return process.env.DEFENDER_API_URL || 'https://defender-api.openzeppelin.com/';
   }
 
   public async listSupportedNetworks(params?: ListNetworkRequestOptions): Promise<Network[]> {

--- a/packages/proposal/src/api/index.ts
+++ b/packages/proposal/src/api/index.ts
@@ -27,7 +27,7 @@ export class ProposalClient extends BaseApiClient {
   }
 
   protected getApiUrl(): string {
-    return process.env.DEFENDER_API_URL || 'https://defender-api.openzeppelin.com/v2/';
+    return process.env.DEFENDER_API_URL || 'https://defender-api.openzeppelin.com/';
   }
 
   public async addContract(contract: Contract): Promise<Contract> {

--- a/packages/relay-signer/src/api/index.ts
+++ b/packages/relay-signer/src/api/index.ts
@@ -10,9 +10,7 @@ import {
 import { JsonRpcResponse, SignMessagePayload, SignTypedDataPayload, SignedMessagePayload } from '../models/rpc';
 import { AuthType } from '@openzeppelin/defender-sdk-base-client/lib/api/auth-v2';
 
-export const getAdminApiUrl = () => process.env.DEFENDER_API_URL || 'https://defender-api.openzeppelin.com/v2/';
-
-export const getRelaySignerApiUrl = () => process.env.DEFENDER_API_URL || 'https://defender-api.openzeppelin.com/v2/';
+export const getApiUrl = () => process.env.DEFENDER_API_URL || 'https://defender-api.openzeppelin.com/';
 
 export class RelaySignerClient extends BaseApiClient implements IRelayer {
   private jsonRpcRequestNextId: number;
@@ -31,7 +29,7 @@ export class RelaySignerClient extends BaseApiClient implements IRelayer {
   }
 
   protected getApiUrl(type?: AuthType): string {
-    return getAdminApiUrl();
+    return getApiUrl();
   }
 
   public async getRelayer(): Promise<RelayerGetResponse> {

--- a/packages/relay-signer/src/ethers/provider-v5.ts
+++ b/packages/relay-signer/src/ethers/provider-v5.ts
@@ -4,14 +4,14 @@ import { DefenderRelaySignerV5 } from './signer-v5';
 import { defineReadOnly, getStatic } from '@ethersproject/properties';
 import { Networkish } from '@ethersproject/networks';
 import { BigNumber } from '@ethersproject/bignumber';
-import { getRelaySignerApiUrl } from '../api';
 import { Relayer } from '../relayer';
+import { getApiUrl } from '../api';
 
 export class DefenderRelayProviderV5 extends StaticJsonRpcProvider {
   private relayer: Relayer;
 
   constructor(readonly credentials: RelayerParams) {
-    super(getRelaySignerApiUrl());
+    super(getApiUrl());
     this.relayer = new Relayer(credentials);
   }
 

--- a/packages/relay-signer/src/ethers/provider.ts
+++ b/packages/relay-signer/src/ethers/provider.ts
@@ -1,6 +1,6 @@
 import { EthersVersion, RelayerParams } from '../models/relayer';
 import { DefenderRelaySigner } from './signer';
-import { getRelaySignerApiUrl } from '../api';
+import { getApiUrl } from '../api';
 import { Relayer } from '../relayer';
 import {
   JsonRpcError,
@@ -21,7 +21,7 @@ export class DefenderRelayProvider extends JsonRpcProvider {
   private pendingNetwork: Promise<Network> | null = null;
 
   constructor(readonly credentials: RelayerParams) {
-    super(getRelaySignerApiUrl());
+    super(getApiUrl());
     this.relayer = new Relayer(credentials);
   }
 

--- a/packages/relay/src/api/index.ts
+++ b/packages/relay/src/api/index.ts
@@ -20,7 +20,7 @@ export class RelayClient extends BaseApiClient {
   }
 
   protected getApiUrl(): string {
-    return process.env.DEFENDER_API_URL || 'https://defender-api.openzeppelin.com/v2/';
+    return process.env.DEFENDER_API_URL || 'https://defender-api.openzeppelin.com/';
   }
 
   public async get(id: string): Promise<RelayerGetResponse> {


### PR DESCRIPTION
# Summary

Removes /v2/ base path in most packages exept blockwatchers and notifiacitons (they are not supported in root basepath)

