### PR TITLE
fix: set private true for e2e

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -2,13 +2,14 @@
   "name": "e2e",
   "version": "1.1.0",
   "description": "",
+  "private": true,
   "main": "index.js",
   "scripts": {
     "test": "jest",
     "test:watch": "jest --watch"
   },
   "keywords": [],
-  "author": "",
+  "author": "OpenZeppelin Defender <defender@openzeppelin.com>",
   "license": "ISC",
   "devDependencies": {
     "@types/jest": "^29.5.12",


### PR DESCRIPTION
# Summary

- Looks like npm publish is failing due to not setting private for e2e as it's added to workspace.
