### PR TITLE
fix: client lambda dependencies with actions example

### DIFF
--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -20,11 +20,11 @@
   "author": "OpenZeppelin Defender <defender@openzeppelin.com>",
   "license": "MIT",
   "devDependencies": {
-    "@aws-sdk/client-lambda": "^3.563.0",
     "@types/async-retry": "^1.4.8",
     "aws-sdk": "^2.1662.0"
   },
   "dependencies": {
+    "@aws-sdk/client-lambda": "^3.563.0",
     "amazon-cognito-identity-js": "^6.3.6",
     "async-retry": "^1.3.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -509,6 +509,9 @@ importers:
 
   packages/base:
     dependencies:
+      '@aws-sdk/client-lambda':
+        specifier: ^3.563.0
+        version: 3.563.0
       amazon-cognito-identity-js:
         specifier: ^6.3.6
         version: 6.3.6
@@ -516,9 +519,6 @@ importers:
         specifier: ^1.3.3
         version: 1.3.3
     devDependencies:
-      '@aws-sdk/client-lambda':
-        specifier: ^3.563.0
-        version: 3.563.0
       '@types/async-retry':
         specifier: ^1.4.8
         version: 1.4.8


### PR DESCRIPTION
# Summary
- This PR will add `@aws-sdk/client-lambda` to dependencies section as this package is being used by defender-sdk package and the users expect this package to be part of the dependencies by default.

