### PR TITLE
fix: type inference in relay signer

### DIFF
--- a/examples/custom-ethers-pkg/src/index.ts
+++ b/examples/custom-ethers-pkg/src/index.ts
@@ -11,8 +11,8 @@ export async function handler(event: ActionEvent | DefenderOptions) {
   console.log(ethers.version);
 
   const client = new Defender(event as DefenderOptions);
-  const provider = client.relaySigner.getProvider();
-  const signer = await client.relaySigner.getSigner(provider, { speed: 'fast' });
+  const provider = client.relaySigner.getProvider({ ethersVersion: 'v6' });
+  const signer = await client.relaySigner.getSigner(provider, { speed: 'fast', ethersVersion: 'v6' });
 
   const erc20BytesLike = ERC20Bytecode[0].data.bytecode.object;
   const factory = new ContractFactory(ERC20Abi, erc20BytesLike, signer);

--- a/packages/relay-signer/src/relayer.ts
+++ b/packages/relay-signer/src/relayer.ts
@@ -28,6 +28,14 @@ import { DefenderRelayProviderV5 } from './ethers/provider-v5';
 import { DefenderRelaySignerOptionsV5, DefenderRelaySignerV5 } from './ethers/signer-v5';
 import { Provider } from '@ethersproject/abstract-provider';
 
+type ProviderType<T extends DefenderRelayProviderOptions> = T['ethersVersion'] extends 'v6'
+  ? DefenderRelayProvider
+  : DefenderRelayProviderV5;
+
+type SignerType<T extends DefenderRelaySignerOptionsV5 | DefenderRelaySignerOptions> = T['ethersVersion'] extends 'v6'
+  ? DefenderRelaySigner
+  : DefenderRelaySignerV5;
+
 export class Relayer implements IRelayer {
   private relayer: IRelayer;
   private credentials: RelayerParams;
@@ -75,22 +83,22 @@ export class Relayer implements IRelayer {
     return this.relayer.getRelayerStatus();
   }
 
-  public getProvider(
-    options: DefenderRelayProviderOptions = { ethersVersion: 'v5' },
-  ): DefenderRelayProvider | DefenderRelayProviderV5 {
+  public getProvider<T extends DefenderRelayProviderOptions>(options?: T): ProviderType<T> {
     if (!this.credentials) throw new Error(`Missing credentials for creating a DefenderRelayProvider instance.`);
-    if (options.ethersVersion === 'v5') return new DefenderRelayProviderV5(this.credentials);
-    return new DefenderRelayProvider(this.credentials);
+    // defaults to ethers v5.
+    if (!options || options.ethersVersion === 'v5')
+      return new DefenderRelayProviderV5(this.credentials) as ProviderType<T>;
+    return new DefenderRelayProvider(this.credentials) as ProviderType<T>;
   }
 
-  public async getSigner(
+  public async getSigner<T extends DefenderRelaySignerOptionsV5 | DefenderRelaySignerOptions>(
     provider: Provider | JsonRpcProvider,
-    options: DefenderRelaySignerOptionsV5 | DefenderRelaySignerOptions,
-  ): Promise<DefenderRelaySigner | DefenderRelaySignerV5> {
+    options: T,
+  ): Promise<SignerType<T>> {
     if (!this.credentials) throw new Error(`Missing credentials for creating a DefenderRelaySigner instance.`);
 
     if (this.isEthersV5Provider(provider, options?.ethersVersion) && this.isEthersV5ProviderOptions(options)) {
-      return new DefenderRelaySignerV5(this.credentials, provider, options);
+      return new DefenderRelaySignerV5(this.credentials, provider, options) as SignerType<T>;
     }
 
     if (!this.isEthersV5Provider(provider, options?.ethersVersion) && !this.isEthersV5ProviderOptions(options)) {
@@ -98,7 +106,7 @@ export class Relayer implements IRelayer {
       if ('relayerGroupId' in relayer) {
         throw new Error('Relayer group is not supported for ethers v6.');
       }
-      return new DefenderRelaySigner(this.credentials, provider, relayer.address, options);
+      return new DefenderRelaySigner(this.credentials, provider, relayer.address, options) as SignerType<T>;
     }
     throw new Error(`Invalid state, provider and options must be for the same ethers version.`);
   }


### PR DESCRIPTION
# Summary

Fixes typescript lint error when using ethers provider and signer
