### PR TITLE
feat(deploy): include immutableReferences in extracted artifact

### DIFF
--- a/packages/deploy/src/models/deployment.ts
+++ b/packages/deploy/src/models/deployment.ts
@@ -107,6 +107,10 @@ export interface BlockExplorerVerification {
 
 export type RequestArtifact = Pick<DeployContractRequest, 'artifactPayload' | 'contractName' | 'contractPath'>;
 
+export type ImmutableReferences = {
+  [key: string]: Array<{ length: number; start: number }>;
+};
+
 export type ContractArtifact = {
   abi: any;
   evm: {
@@ -117,6 +121,7 @@ export type ContractArtifact = {
     deployedBytecode: {
       object: string;
       linkReferences: any;
+      immutableReferences: ImmutableReferences;
     };
   };
   metadata: string;

--- a/packages/deploy/src/utils/deploy.test.ts
+++ b/packages/deploy/src/utils/deploy.test.ts
@@ -34,6 +34,8 @@ describe('Deploy utilities', () => {
                   object: artifact.output.contracts['contracts/Box.sol'].Box.evm.deployedBytecode.object,
                   linkReferences:
                     artifact.output.contracts['contracts/Box.sol'].Box.evm.deployedBytecode.linkReferences,
+                  immutableReferences:
+                    artifact.output.contracts['contracts/Box.sol'].Box.evm.deployedBytecode.immutableReferences,
                 },
               },
               metadata: artifact.output.contracts['contracts/Box.sol'].Box.metadata,

--- a/packages/deploy/src/utils/deploy.ts
+++ b/packages/deploy/src/utils/deploy.ts
@@ -37,6 +37,7 @@ export function extractArtifact({
               deployedBytecode: {
                 object: contract.evm.deployedBytecode.object,
                 linkReferences: contract.evm.deployedBytecode.linkReferences,
+                immutableReferences: contract.evm.deployedBytecode.immutableReferences,
               },
             },
             metadata: contract.metadata,


### PR DESCRIPTION
# Summary

Includes `immutableReferences` object from the build data when extracting the artifact data necessary for the deploy with Defender.

`immutableReferences` object is used to locate any slots that need to be considered when comparing and verifying on-chain bytecode with the `deployedBytecode` from the artifact. For example immutable variables are used in upgradeable contracts and their proxies depending on the type of the upgradeable contract.

This PR will fix an existing issue with Defender not being able to verify bytecodes of the contracts that use immutable variables.