### PR TITLE
feat: add attribute to detect the deployment origin

### DIFF
--- a/packages/deploy/src/api/deployment.test.ts
+++ b/packages/deploy/src/api/deployment.test.ts
@@ -82,6 +82,26 @@ describe('Deploy Client', () => {
       expect(deployClient.api.post).toBeCalledWith('/deployments', deployCreatePayload);
       expect(createAuthenticatedApi).toBeCalled();
     });
+    it('adds origin to the payload if not provided', async () => {
+      await deployClient.deployContract(deployCreatePayload);
+      expect(deployClient.api.post).toHaveBeenCalledWith(
+        '/deployments',
+        expect.objectContaining({
+          origin: 'SDK',
+        }),
+      );
+      expect(createAuthenticatedApi).toHaveBeenCalled();
+    });
+    it('allows custom origin', async () => {
+      await deployClient.deployContract({ ...deployCreatePayload, origin: 'Foundry' });
+      expect(deployClient.api.post).toHaveBeenCalledWith(
+        '/deployments',
+        expect.objectContaining({
+          origin: 'Foundry',
+        }),
+      );
+      expect(createAuthenticatedApi).toHaveBeenCalled();
+    });
   });
   describe('get', () => {
     it('calls API correctly', async () => {

--- a/packages/deploy/src/api/index.ts
+++ b/packages/deploy/src/api/index.ts
@@ -42,6 +42,10 @@ export class DeployClient extends BaseApiClient {
       params.artifactPayload = JSON.stringify(extractArtifact(params));
     }
 
+    // If the origin is not provided,
+    // we assume the deployment was made using the SDK
+    if (!params.origin) params.origin = 'SDK';
+
     return this.apiCall(async (api) => {
       return api.post(`${DEPLOYMENTS_PATH}`, params);
     });

--- a/packages/deploy/src/models/deployment.ts
+++ b/packages/deploy/src/models/deployment.ts
@@ -51,7 +51,7 @@ export interface DeployContractRequest {
    */
   txOverrides?: TxOverrides;
   /**
-   * @description A key-value pair to be included in the deployment.
+   * @description Key-value pairs to be included in the deployment.
    */
   metadata?: DeployMetadata;
   /**

--- a/packages/deploy/src/models/deployment.ts
+++ b/packages/deploy/src/models/deployment.ts
@@ -46,14 +46,20 @@ export interface DeployContractRequest {
   approvalProcessId?: string;
   createFactoryAddress?: string;
   /**
-   * Only applies to Relayers approval processes, for other default approval processes it has no effect
+   * @description Only applies to Relayers approval processes, for other default approval processes it has no effect
    * @default undefined
    */
   txOverrides?: TxOverrides;
-  /*
-   * A note to be included in the deployment.
+  /**
+   * @description A note to be included in the deployment.
    */
   metadata?: DeployMetadata;
+  /**
+   * @description The client that made the deployment. For internal use only.
+   * @warning this variable does not represent the `tx.origin` of the deployment.
+   * @default 'SDK'
+   */
+  origin?: DeploymentOrigin;
 }
 export interface DeployRequestLibraries {
   [k: `${string}:${string}`]: string;
@@ -69,6 +75,8 @@ export interface DeploymentUpdateRequest {
   txHash?: string;
   address?: Address;
 }
+
+export type DeploymentOrigin = 'SDK' | 'Foundry' | 'Hardhat' | 'Remix' | 'Wizard';
 
 export interface DeploymentResponse {
   deploymentId: string;
@@ -98,6 +106,7 @@ export interface DeploymentResponse {
     [k: string]: string;
   };
   constructorInputs?: (string | boolean | number)[];
+  origin?: DeploymentOrigin;
 }
 export interface BlockExplorerVerification {
   status: string;

--- a/packages/deploy/src/models/deployment.ts
+++ b/packages/deploy/src/models/deployment.ts
@@ -51,7 +51,7 @@ export interface DeployContractRequest {
    */
   txOverrides?: TxOverrides;
   /**
-   * @description A note to be included in the deployment.
+   * @description A key-value pair to be included in the deployment.
    */
   metadata?: DeployMetadata;
   /**


### PR DESCRIPTION
# Summary

Add `origin` attribute to deployments to detect the client origin that sent the deployment request

## Checklist

- [x] Add unit tests if applicable.
