### PR TITLE
chore: Allow the upstream setup branch step not to fail when the branch doesn't exist

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -49,7 +49,6 @@ jobs:
         shell: bash
 
       - name: Set up upstream branch
-        continue-on-error: true
         run: |
           if git show-ref --verify --quiet refs/remotes/origin/changeset-release/main; then
             git push --set-upstream origin changeset-release/main


### PR DESCRIPTION
# Summary

Allow the upstream setup branch step not to fail when the branch doesn't exist

## Testing Process

## Checklist

- [ ] Add a reference to related issues in the PR description.
- [ ] Add unit tests if applicable.
