### PR TITLE
fix(deploy): PLAT-6273 Add all input sources for dependency validation

### DIFF
--- a/packages/deploy/src/models/deployment.ts
+++ b/packages/deploy/src/models/deployment.ts
@@ -144,6 +144,7 @@ export type Artifact = {
       };
     };
     settings: any;
+    language: string;
   };
   output: {
     contracts: {

--- a/packages/deploy/src/utils/deploy.test.ts
+++ b/packages/deploy/src/utils/deploy.test.ts
@@ -18,6 +18,7 @@ describe('Deploy utilities', () => {
             content: artifact.input.sources['contracts/Box.sol'].content,
           },
         },
+        language: 'Solidity',
         settings: artifact.input.settings,
       },
       output: {

--- a/packages/deploy/src/utils/deploy.ts
+++ b/packages/deploy/src/utils/deploy.ts
@@ -19,9 +19,7 @@ export function extractArtifact({
 
   return {
     input: {
-      sources: {
-        [path]: source,
-      },
+      sources: artifactObj.input.sources,
       settings,
     },
     output: {

--- a/packages/deploy/src/utils/deploy.ts
+++ b/packages/deploy/src/utils/deploy.ts
@@ -14,12 +14,15 @@ export function extractArtifact({
 
   const source = artifactObj.input.sources[path];
   const settings = artifactObj.input.settings;
-  if (!source) throw new Error(`Contract ${name} source not found in artifact ${artifact}`);
-  if (!settings) throw new Error(`Contract ${name} settings not found in artifact ${artifact}`);
+  const language = artifactObj.input.language;
+  if (!source) throw new Error(`Contract ${name} source not found in artifact.input ${artifact}`);
+  if (!settings) throw new Error(`Contract ${name} settings not found in artifact.input ${artifact}`);
+  if (!language) throw new Error(`Contract ${name} language not found in artifact.input ${artifact}`);
 
   return {
     input: {
       sources: artifactObj.input.sources,
+      language,
       settings,
     },
     output: {


### PR DESCRIPTION
# Summary

When verifying contract on Etherscan the content source code content of the dependency of the contract are required alongside the contract's source code content.