### PR TITLE
feat(Deploy-BE): PLAT-6398 include deploy network type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openzeppelin/defender-sdk",
-  "version": "0.0.1",
+  "version": "0.0.0",
   "private": true,
   "description": "The OpenZeppelin Defender Software Development Kit",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openzeppelin/defender-sdk",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "private": true,
   "description": "The OpenZeppelin Defender Software Development Kit",
   "dependencies": {

--- a/packages/defender-sdk/src/index.ts
+++ b/packages/defender-sdk/src/index.ts
@@ -12,7 +12,10 @@ import { KeyValueStoreClient, LocalKeyValueStoreCreateParams } from '@openzeppel
 import { AddressBookClient } from '@openzeppelin/defender-sdk-address-book-client';
 import { Newable, ClientParams } from './types';
 import { ActionRelayerParams, Relayer as RelaySignerClient } from '@openzeppelin/defender-sdk-relay-signer-client';
-import { ListNetworkRequestOptions } from '@openzeppelin/defender-sdk-network-client/lib/models/networks';
+import {
+  ListNetworkRequestOptions,
+  NetworkDefinition,
+} from '@openzeppelin/defender-sdk-network-client/lib/models/networks';
 import { AuthConfig, Network, RetryConfig } from '@openzeppelin/defender-sdk-base-client';
 import https from 'https';
 import {
@@ -76,14 +79,21 @@ export class Defender {
     };
   }
 
-  public networks(opts?: ListNetworkRequestOptions): Promise<Network[]> {
-    return getClient(NetworkClient, {
+  public async networks(params: ListNetworkRequestOptions & { includeDefinition: true }): Promise<NetworkDefinition[]>;
+  public async networks(params?: ListNetworkRequestOptions & { includeDefinition?: false }): Promise<Network[]>;
+
+  public networks(opts: ListNetworkRequestOptions = {}): Promise<Network[] | NetworkDefinition[]> {
+    const client = getClient(NetworkClient, {
       apiKey: this.apiKey,
       apiSecret: this.apiSecret,
       httpsAgent: this.httpsAgent,
       retryConfig: this.retryConfig,
       authConfig: this.authConfig,
-    }).listSupportedNetworks(opts);
+    });
+
+    return opts.includeDefinition
+      ? client.listSupportedNetworks({ ...opts, includeDefinition: true })
+      : client.listSupportedNetworks({ ...opts, includeDefinition: false });
   }
 
   get network() {

--- a/packages/network/src/api/index.test.ts
+++ b/packages/network/src/api/index.test.ts
@@ -122,9 +122,9 @@ describe('NetworkClient', () => {
       expect(createAuthenticatedApi).toBeCalled();
     });
 
-    it('calls API correctly with network type', async () => {
-      await networkClient.listSupportedNetworks({ networkType: 'deploy' });
-      expect(networkClient.api.get).toBeCalledWith('/networks?type=deploy');
+    it('calls API correctly with multiple network types', async () => {
+      await networkClient.listSupportedNetworks({ networkType: ['deploy', 'production'] });
+      expect(networkClient.api.get).toBeCalledWith('/networks?type=deploy,production');
       expect(createAuthenticatedApi).toBeCalled();
     });
   });

--- a/packages/network/src/api/index.test.ts
+++ b/packages/network/src/api/index.test.ts
@@ -121,6 +121,12 @@ describe('NetworkClient', () => {
       expect(networkClient.api.get).toBeCalledWith('/networks?type=production');
       expect(createAuthenticatedApi).toBeCalled();
     });
+
+    it('calls API correctly with network type', async () => {
+      await networkClient.listSupportedNetworks({ networkType: 'deploy' });
+      expect(networkClient.api.get).toBeCalledWith('/networks?type=deploy');
+      expect(createAuthenticatedApi).toBeCalled();
+    });
   });
 
   describe('list', () => {

--- a/packages/network/src/api/index.test.ts
+++ b/packages/network/src/api/index.test.ts
@@ -124,7 +124,7 @@ describe('NetworkClient', () => {
 
     it('calls API correctly with multiple network types', async () => {
       await networkClient.listSupportedNetworks({ networkType: ['deploy', 'production'] });
-      expect(networkClient.api.get).toBeCalledWith('/networks?type=deploy,production');
+      expect(networkClient.api.get).toBeCalledWith('/networks?type=deploy%2Cproduction');
       expect(createAuthenticatedApi).toBeCalled();
     });
 
@@ -136,7 +136,7 @@ describe('NetworkClient', () => {
 
     it('calls API correctly with includeDefinition flag and includeDefinition flag', async () => {
       await networkClient.listSupportedNetworks({ networkType: ['deploy', 'production'], includeDefinition: true });
-      expect(networkClient.api.get).toBeCalledWith('/networks?type=deploy,production&includeDefinition=true');
+      expect(networkClient.api.get).toBeCalledWith('/networks?type=deploy%2Cproduction&includeDefinition=true');
       expect(createAuthenticatedApi).toBeCalled();
     });
   });

--- a/packages/network/src/api/index.test.ts
+++ b/packages/network/src/api/index.test.ts
@@ -127,6 +127,18 @@ describe('NetworkClient', () => {
       expect(networkClient.api.get).toBeCalledWith('/networks?type=deploy,production');
       expect(createAuthenticatedApi).toBeCalled();
     });
+
+    it('calls API correctly with includeDefinition flag', async () => {
+      await networkClient.listSupportedNetworks({ includeDefinition: true });
+      expect(networkClient.api.get).toBeCalledWith('/networks?includeDefinition=true');
+      expect(createAuthenticatedApi).toBeCalled();
+    });
+
+    it('calls API correctly with includeDefinition flag and includeDefinition flag', async () => {
+      await networkClient.listSupportedNetworks({ networkType: ['deploy', 'production'], includeDefinition: true });
+      expect(networkClient.api.get).toBeCalledWith('/networks?type=deploy,production&includeDefinition=true');
+      expect(createAuthenticatedApi).toBeCalled();
+    });
   });
 
   describe('list', () => {

--- a/packages/network/src/api/index.ts
+++ b/packages/network/src/api/index.ts
@@ -26,14 +26,19 @@ export class NetworkClient extends BaseApiClient {
   }
 
   public async listSupportedNetworks(params: ListNetworkRequestOptions = {}): Promise<Network[]> {
+    const queryParams: string[] = [];
+
+    if (params.networkType) {
+      const networkTypes = Array.isArray(params.networkType) ? params.networkType : [params.networkType];
+      queryParams.push(`type=${encodeURIComponent(networkTypes.join(','))}`);
+    }
+
+    if (params.includeDefinition) {
+      queryParams.push('includeDefinition=true');
+    }
+
     return this.apiCall(async (api) => {
-      return await api.get(
-        `${PATH}${
-          params.networkType
-            ? `type=${(Array.isArray(params.networkType) ? params.networkType : [params.networkType]).toString()}`
-            : ''
-        }${params.includeDefinition ? '&includeDefinition=true' : ''}`,
-      );
+      return await api.get(`${PATH}${queryParams.length ? `?${queryParams.join('&')}` : ''}`);
     });
   }
 

--- a/packages/network/src/api/index.ts
+++ b/packages/network/src/api/index.ts
@@ -27,7 +27,11 @@ export class NetworkClient extends BaseApiClient {
 
   public async listSupportedNetworks(params?: ListNetworkRequestOptions): Promise<Network[]> {
     return this.apiCall(async (api) => {
-      return await api.get(params && params.networkType ? `${PATH}?type=${params.networkType}` : `${PATH}`);
+      return await api.get(
+        params && params.networkType
+          ? `${PATH}?type=${(Array.isArray(params.networkType) ? params.networkType : [params.networkType]).toString()}`
+          : `${PATH}`,
+      );
     });
   }
 

--- a/packages/network/src/api/index.ts
+++ b/packages/network/src/api/index.ts
@@ -33,7 +33,9 @@ export class NetworkClient extends BaseApiClient {
     params?: ListNetworkRequestOptions & { includeDefinition?: false },
   ): Promise<Network[]>;
 
-  public async listSupportedNetworks(params: ListNetworkRequestOptions = {}): Promise<Network[] | NetworkDefinition[]> {
+  public async listSupportedNetworks(
+    params: ListNetworkRequestOptions = { includeDefinition: false },
+  ): Promise<Network[] | NetworkDefinition[]> {
     const queryParams: string[] = [];
 
     if (params.networkType) {

--- a/packages/network/src/api/index.ts
+++ b/packages/network/src/api/index.ts
@@ -25,12 +25,14 @@ export class NetworkClient extends BaseApiClient {
     return process.env.DEFENDER_API_URL || 'https://defender-api.openzeppelin.com/';
   }
 
-  public async listSupportedNetworks(params?: ListNetworkRequestOptions): Promise<Network[]> {
+  public async listSupportedNetworks(params: ListNetworkRequestOptions = {}): Promise<Network[]> {
     return this.apiCall(async (api) => {
       return await api.get(
-        params && params.networkType
-          ? `${PATH}?type=${(Array.isArray(params.networkType) ? params.networkType : [params.networkType]).toString()}`
-          : `${PATH}`,
+        `${PATH}${
+          params.networkType
+            ? `type=${(Array.isArray(params.networkType) ? params.networkType : [params.networkType]).toString()}`
+            : ''
+        }${params.includeDefinition ? '&includeDefinition=true' : ''}`,
       );
     });
   }

--- a/packages/network/src/api/index.ts
+++ b/packages/network/src/api/index.ts
@@ -30,7 +30,7 @@ export class NetworkClient extends BaseApiClient {
     params: ListNetworkRequestOptions & { includeDefinition: true },
   ): Promise<NetworkDefinition[]>;
   public async listSupportedNetworks(
-    params?: ListNetworkRequestOptions & { includeDefinition?: false | undefined },
+    params?: ListNetworkRequestOptions & { includeDefinition?: false },
   ): Promise<Network[]>;
 
   public async listSupportedNetworks(params: ListNetworkRequestOptions = {}): Promise<Network[] | NetworkDefinition[]> {

--- a/packages/network/src/api/index.ts
+++ b/packages/network/src/api/index.ts
@@ -8,6 +8,7 @@ import {
   PrivateNetworkCreateRequest,
   PrivateNetworkResponse,
   PrivateNetworkUpdateRequest,
+  NetworkDefinition,
 } from '../models/networks';
 
 const PATH = '/networks';
@@ -25,7 +26,14 @@ export class NetworkClient extends BaseApiClient {
     return process.env.DEFENDER_API_URL || 'https://defender-api.openzeppelin.com/';
   }
 
-  public async listSupportedNetworks(params: ListNetworkRequestOptions = {}): Promise<Network[]> {
+  public async listSupportedNetworks(
+    params: ListNetworkRequestOptions & { includeDefinition: true },
+  ): Promise<NetworkDefinition[]>;
+  public async listSupportedNetworks(
+    params?: ListNetworkRequestOptions & { includeDefinition?: false | undefined },
+  ): Promise<Network[]>;
+
+  public async listSupportedNetworks(params: ListNetworkRequestOptions = {}): Promise<Network[] | NetworkDefinition[]> {
     const queryParams: string[] = [];
 
     if (params.networkType) {

--- a/packages/network/src/index.ts
+++ b/packages/network/src/index.ts
@@ -7,6 +7,7 @@ export {
   NetworkType,
   TenantNetworkType,
   TenantNetworkResponse,
+  NetworkDefinition,
 } from './models/networks';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires

--- a/packages/network/src/models/networks.ts
+++ b/packages/network/src/models/networks.ts
@@ -1,6 +1,6 @@
 import { SupportedNetwork, TenantNetwork } from '@openzeppelin/defender-sdk-base-client';
 
-export type NetworkType = 'production' | 'test';
+export type NetworkType = 'production' | 'test' | 'deploy';
 export type TenantNetworkType = 'private' | 'fork';
 export type Address = string;
 

--- a/packages/network/src/models/networks.ts
+++ b/packages/network/src/models/networks.ts
@@ -9,6 +9,14 @@ export interface ListNetworkRequestOptions {
   includeDefinition?: boolean;
 }
 
+export type NetworkDefinition = {
+  name: string;
+  displayName: string;
+  chainId: number;
+  symbol: string;
+  isProduction: boolean;
+};
+
 export interface TenantNetworkCreateRequest {
   name: string;
   supportedNetwork?: SupportedNetwork;

--- a/packages/network/src/models/networks.ts
+++ b/packages/network/src/models/networks.ts
@@ -5,7 +5,7 @@ export type TenantNetworkType = 'private' | 'fork';
 export type Address = string;
 
 export interface ListNetworkRequestOptions {
-  networkType?: NetworkType;
+  networkType?: NetworkType | NetworkType[];
 }
 
 export interface TenantNetworkCreateRequest {

--- a/packages/network/src/models/networks.ts
+++ b/packages/network/src/models/networks.ts
@@ -6,6 +6,7 @@ export type Address = string;
 
 export interface ListNetworkRequestOptions {
   networkType?: NetworkType | NetworkType[];
+  includeDefinition?: boolean;
 }
 
 export interface TenantNetworkCreateRequest {

--- a/packages/network/src/models/networks.ts
+++ b/packages/network/src/models/networks.ts
@@ -9,13 +9,13 @@ export interface ListNetworkRequestOptions {
   includeDefinition?: boolean;
 }
 
-export type NetworkDefinition = {
+export interface NetworkDefinition {
   name: string;
   displayName: string;
   chainId: number;
   symbol: string;
   isProduction: boolean;
-};
+}
 
 export interface TenantNetworkCreateRequest {
   name: string;


### PR DESCRIPTION
# Summary

Adjust typing to support "deploy" network type (will be used in deploy plugin to filter out networks that do not support deployment by Defender
