### PR TITLE
docs(proposals): Clarify distinction between Safe and Gnosis Multisig viaType options

### DIFF
--- a/packages/proposal/src/models/proposal.ts
+++ b/packages/proposal/src/models/proposal.ts
@@ -17,6 +17,13 @@ export interface ExternalApiCreateProposalRequest {
   type: ProposalType;
   metadata?: ProposalMetadata;
   via?: Address;
+  /**
+   * The type of account or mechanism that will execute the proposal:
+   * - 'EOA': An externally owned account (regular wallet)
+   * - 'Safe': A Safe (formerly Gnosis Safe) multi-signature wallet
+   * - 'Gnosis Multisig': A legacy Gnosis multi-signature wallet (not Safe)
+   * - 'Relayer': A Defender Relayer
+   */
   viaType?: 'EOA' | 'Safe' | 'Gnosis Multisig' | 'Relayer';
   functionInterface?: ProposalTargetFunction;
   functionInputs?: ProposalFunctionInputs;


### PR DESCRIPTION

# Summary

This PR adds documentation to clarify the distinction between "Gnosis Multisig" and "Safe" in the `viaType` property of the `ExternalApiCreateProposalRequest` interface. The added JSDoc comments explain that "Safe" refers to the newer "Gnosis Safe" multi-signature wallets (which have been rebranded to just "Safe"), while "Gnosis Multisig" refers to the legacy implementation.

This addresses issue [#553](https://github.com/OpenZeppelin/defender-sdk/issues/553) where users might be confused about the difference between these two options when creating proposals.

Changes:
- Added comprehensive JSDoc comments to document all four `viaType` options
- Clearly differentiated between "Safe" and "Gnosis Multisig"
- Included explanations for "EOA" and "Relayer" options for completeness

## Testing Process

This is a documentation-only change. Manual verification was performed to ensure the JSDoc comments are properly formatted and accurately explain the differences between the various `viaType` options.

## Checklist

- [x] Add a reference to related issues in the PR description.
- [x] Add unit tests if applicable. (N/A - documentation only change)
