### PR TITLE
docs(proposals): Clarify distinction between Safe and Gnosis Multisig viaType options (#553)

### DIFF
--- a/packages/proposal/src/models/proposal.ts
+++ b/packages/proposal/src/models/proposal.ts
@@ -17,6 +17,13 @@ export interface ExternalApiCreateProposalRequest {
   type: ProposalType;
   metadata?: ProposalMetadata;
   via?: Address;
+  /**
+   * The type of account or mechanism that will execute the proposal:
+   * - 'EOA'              : An externally owned account          (hot wallet)
+   * - 'Safe'             : A Safe multi-signature wallet        (formerly Gnosis Safe)
+   * - 'Gnosis Multisig'  : A legacy Gnosis multi-signature wallet      (not Safe)
+   * - 'Relayer'          : A Defender Relayer                  (cloud signer)
+   */
   viaType?: 'EOA' | 'Safe' | 'Gnosis Multisig' | 'Relayer';
   functionInterface?: ProposalTargetFunction;
   functionInputs?: ProposalFunctionInputs;


### PR DESCRIPTION
# Description
This PR adds clear documentation to distinguish between "Gnosis Multisig" and "Safe" in the `viaType` property of the `ExternalApiCreateProposalRequest` interface. The JSDoc comments now properly explain:

- 'EOA'              : An externally owned account          (hot wallet)
- 'Safe'             : A Safe multi-signature wallet        (formerly Gnosis Safe)
- 'Gnosis Multisig'  : A legacy Gnosis multi-signature wallet      (not Safe)
- 'Relayer'          : A Defender Relayer                  (cloud signer)

This addresses issue [#553](https://github.com/OpenZeppelin/defender-sdk/issues/553) where users needed clarity on the difference between these wallet options.

## Testing Process
Documentation-only change. Manual verification performed to ensure:
- Proper JSDoc formatting
- Clear distinction between wallet types
- Consistent spacing and alignment

## Checklist
- [x] Add a reference to related issues in the PR description.

